### PR TITLE
Add missing group path in gradle.build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ jar {
     version =  System.getenv('version')
 }
 
+group = "edu.kit.datamanager"
+
 repositories {
     mavenLocal()   
     mavenCentral()


### PR DESCRIPTION
This enables to test local changes in service-base with other services. For example by pushing it to the local maven repository:

1. `./gradlew install` in local service-base repository containing the changes
2. i.e. in pit-service adjust the version number to the local change if neccessary
3. build pit-service

Without this change, the local repository would store service-base in the wrong location. It will not only not work, but also give unhelpful error messages. After fighting this problem for many hours, I should also note some other findings here:

Note that especially for local testing, pushing to the local maven repository is not recommended ([When (not) to use mavenLocal (official documentation)](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local), [Blog post about this topic](https://medium.com/decisionbrain/when-to-not-use-mavenlocal-in-your-gradle-build-script-6da03902f9df)).

Instead it is recommended to use "[composite builds (official documentation)](https://docs.gradle.org/current/userguide/composite_builds.html#composite_builds)" ([basic example](https://docs.gradle.org/current/samples/sample_composite_builds_basics.html#header)), which sounds special in gradle, but in most other build systems simply means to temporary override/patch a dependency for testing purposes. Usually this is not persisted in the build files so it is not accidentially committed. The easiest way to do it with gradle:

- assuming you want to test changes in service-base, located in code/service-base, using the pit-service located in code/pit-service
- `cd code/pit-service && ./gradlew --include-build ../service-base build`

No changes in build files are needed. It will override existing depencencies to service-base. Other ways can be found in the official documentation. This merge-request is also necessary to support composite builds.